### PR TITLE
Remove "remove intro" button

### DIFF
--- a/src/views/books/book-overview.vue
+++ b/src/views/books/book-overview.vue
@@ -1,8 +1,7 @@
 <template>
     <section>
     <app-header :showBackButton="false" :pageName="$t('books.books')" />
-    <section v-if="showIntro" id="literature-intro" class="container intro">
-        <a class="minimize-button button-circular small secondary" @click="showIntro=false"></a>
+    <section id="literature-intro" class="container intro">
         <section class="center x-small" v-html="$t('books.welcome-message')"></section>
     </section>
     <section class="container">
@@ -40,7 +39,6 @@ export default {
     },
     data: function() {
         return {
-            showIntro: true,
         };
     },
     mixins: [GridMixin],


### PR DESCRIPTION
This removes the button so that the header is always visible, you cant remove it.
![image](https://user-images.githubusercontent.com/727125/113107135-da4d7a80-9203-11eb-91ae-8c48a4bebb5c.png)

Why:

- It currently reappears after a refresh, which can be confusing and seems like a bug.
- The header is a nice design element on the front page, so removing it permanently when you click the X is probably a bad idea.