### PR TITLE
Added remember scroll progress feature

### DIFF
--- a/src/views/books/book-reader.vue
+++ b/src/views/books/book-reader.vue
@@ -181,7 +181,24 @@ export default {
             });
         },
         afterInitialize() {
-            this.scrollToChapter(this.chapterId);
+            let currentBookData = window.localStorage.getItem("book_"+this.bookId+"_scroll_progress").split(" "),
+                relativeScroll = currentBookData? parseFloat(currentBookData[1]) : false;
+            if(currentBookData){
+                this.changeChapter(parseInt(currentBookData[0],10));
+                window.scrollTo(window.scrollX,window.scrollY + relativeScroll);
+            }
+            
+            let preventExhaustionTimeout;
+            function saveProgress(){
+                if(preventExhaustionTimeout) clearTimeout(preventExhaustionTimeout);
+                preventExhaustionTimeout = setTimeout(()=>{
+                    let chapterHeaders = [...document.querySelectorAll(".chapter-header")],
+                        currentChapter = chapterHeaders.filter(x=>x.innerText.split(" ")[1]===""+this.chapterId)[0],
+                        relativeScroll = window.scrollY - currentChapter.offsetTop;
+                    window.localStorage.setItem("book_"+this.bookId+"_scroll_progress",this.chapterId+" "+relativeScroll);
+                },200);
+            }
+            window.addEventListener("scroll",saveProgress);
 
             // Play the audiobook or Listen on BMM
             if (this.$route.hash == '#play' ||


### PR DESCRIPTION
I added an onscroll event which stores in LocalStorage the current scrollY relatively to the last chapter header. But before this it gets the stored current chapter and relative scroll and scrolls to the required position after scroolling to the required chapter.
It may not be the best solution, but it's at least something. This feature is a must!
This contribution was made in my free time.